### PR TITLE
Main Polychromics Fix

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -295,6 +295,7 @@
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"					//from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_WEARERCROSSED "wearer_crossed"                //called on item when crossed by something (): (/atom/movable, mob/living/crossed)
 #define COMSIG_ITEM_MICROWAVE_ACT "microwave_act"                //called on item when microwaved (): (obj/machinery/microwave/M)
+#define COMSIG_ITEM_WORN_OVERLAYS "item_worn_overlays"			//from base of obj/item/worn_overlays(): (isinhands, icon_file, used_state, style_flags, list/overlays)     // Waspstation Edit - Polychromic Fix
 #define COMSIG_ITEM_SHARPEN_ACT "sharpen_act"                	//from base of item/sharpener/attackby(): (amount, max)
 	#define COMPONENT_BLOCK_SHARPEN_APPLIED 1
 	#define COMPONENT_BLOCK_SHARPEN_BLOCKED 2

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -10,10 +10,11 @@
 						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
 
 // Helper similar to image()
-/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE)
+/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, color = "#FFFFFF")      // Waspstation Edit - Polychromic Fix
 	var/mutable_appearance/MA = new()
 	MA.icon = icon
 	MA.icon_state = icon_state
 	MA.layer = layer
 	MA.plane = plane
+	MA.color = color                                                                                              // Waspstation Edit - Polychromic Fix
 	return MA

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -486,9 +486,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 //Overlays for the worn overlay so you can overlay while you overlay
 //eg: ammo counters, primed grenade flashing, etc.
 //"icon_file" is used automatically for inhands etc. to make sure it gets the right inhand file
-/obj/item/proc/worn_overlays(isinhands = FALSE, icon_file, used_state)
+/obj/item/proc/worn_overlays(isinhands = FALSE, icon_file, used_state, style_flags = NONE)           // Waspstation Edit - Polychromic Fix
 	. = list()
-	SEND_SIGNAL(src, COMSIG_ITEM_WORN_OVERLAYS, isinhands, icon_file, used_state, .)
+	SEND_SIGNAL(src, COMSIG_ITEM_WORN_OVERLAYS, isinhands, icon_file, used_state, style_flags, .)    // Waspstation Edit - Polychromic Fix
 //Wasp End
 
 ///sometimes we only want to grant the item's action if it's equipped in a specific slot.


### PR DESCRIPTION
## About The Pull Request

Fixed "color" runtime by adding the color variable to mutable_appearence.dm as it existed in Cit.  This created a second runtime that complained about using += on overlays in polychromic.dm.  Defining COMSIG_ITEM_WORN_OVERLAYS and adding style_flags to worn_overlays() appears to have corrected this issue.

Known issues:
The primary color of the cloak will not change on the sprite that the character wears.
No colors of the coat will change on the sprite the character wears except on the hood.

## Why It's Good For The Game

Makes the majority of the polychromic sprites work. 

## Changelog
:cl:
fix: Majority of polychromic clothes can change color
/:cl:
